### PR TITLE
Strip leading whitespace in pacman.conf

### DIFF
--- a/src/config.nim
+++ b/src/config.nim
@@ -64,7 +64,7 @@ proc readConfigFile*(configFile: string):
         var matches: array[2, string]
 
         while true:
-          let line = readLine(file).strip(leading = false, trailing = true)
+          let line = readLine(file).strip(leading = true, trailing = true)
           if line.len > 0 and line[0] != '#':
             if line.match(re"\[(.*)\]", matches):
               currentCategory = matches[0]
@@ -74,10 +74,10 @@ proc readConfigFile*(configFile: string):
                 category = newTable[string, string]()
                 table[currentCategory] = category
             elif currentCategory.len > 0:
-              if line.match(re"\ *(\w+)\ *=\ *(.*)", matches):
+              if line.match(re"(\w+)\ *=\ *(.*)", matches):
                 category[].add(matches[0], matches[1])
               else:
-                category[].add(line.strip(leading = true, trailing = false), "")
+                category[].add(line, "")
 
         false
       except EOFError:


### PR DESCRIPTION
A little story behind this. I was testing out pakku and was wondering why colours were not working. Eventually I figured out none of my config options were respected.

As it turned out this is because my config has a space before the options section:
```
<space>[options]
foo = bar
```

This in turn made it so pakku silently ignored my options. I fixed this but there still may be some improvement to be done so that if something similar ever happens again it will not fail silently.