### PR TITLE
Make pakku search the AUR by "name and description"

### DIFF
--- a/src/aur.nim
+++ b/src/aur.nim
@@ -129,7 +129,7 @@ proc findAurPackages*(query: seq[string], repo: string, useTimeout: bool):
     withAur():
       try:
         withCurl(instance):
-          let url = aurUrl & "rpc/?v=5&type=search&by=name&arg=" &
+          let url = aurUrl & "rpc/?v=5&type=search&by=name-desc&arg=" &
             instance.escape(query[0])
 
           let response = performString(url, useTimeout)


### PR DESCRIPTION
to make pakku -Ss consistent for packages in the AUR and ones not in the AUR, and to make it compliant with the pacman documentation for `-Ss`.

Fixes #31.