### PR TITLE
Add 'PrintLocalIsNewer' config option

### DIFF
--- a/doc/pakku.conf.5.txt
+++ b/doc/pakku.conf.5.txt
@@ -43,6 +43,10 @@ Options
 	Print warnings during upgrade operation when foreign packages were not
 	found in AUR.
 
+*PrintLocalIsNewer*::
+	Print warnings during upgrade operation when local packages are newer
+	than those found in remote repositories.
+
 *SudoExec*::
 	Automatically exec the program from root via sudo if it is necessary,
 	allowing you to enter password for sudo only once.

--- a/pakku.conf
+++ b/pakku.conf
@@ -9,6 +9,7 @@ AurComments
 CheckIgnored
 #IgnoreArch
 PrintAurNotFound
+PrintLocalIsNewer
 #SudoExec
 #ViewNoDefault
 

--- a/src/config.nim
+++ b/src/config.nim
@@ -47,6 +47,7 @@ type
     checkIgnored*: bool
     ignoreArch*: bool
     printAurNotFound*: bool
+    printLocalIsNewer*: bool
     sudoExec*: bool
     viewNoDefault*: bool
     preserveBuilt*: PreserveBuilt
@@ -155,6 +156,7 @@ proc obtainConfig*(config: PacmanConfig): Config =
   let checkIgnored = options.hasKey("CheckIgnored")
   let ignoreArch = options.hasKey("IgnoreArch")
   let printAurNotFound = options.hasKey("PrintAurNotFound")
+  let printLocalIsNewer = options.hasKey("PrintLocalIsNewer")
   let sudoExec = options.hasKey("SudoExec")
   let viewNoDefault = options.hasKey("ViewNoDefault")
   let preserveBuilt = toSeq(enumerate[PreserveBuilt]())
@@ -179,8 +181,8 @@ proc obtainConfig*(config: PacmanConfig): Config =
     userCacheCurrent: userCacheCurrent, tmpRootInitial: tmpRootInitial,
     tmpRootCurrent: tmpRootCurrent, color: color, aurRepo: aurRepo, aurComments: aurComments,
     checkIgnored: checkIgnored, ignoreArch: ignoreArch, printAurNotFound: printAurNotFound,
-    sudoExec: sudoExec, viewNoDefault: viewNoDefault, preserveBuilt: preserveBuilt,
-    preBuildCommand: preBuildCommand)
+    printLocalIsNewer: printLocalIsNewer, sudoExec: sudoExec, viewNoDefault: viewNoDefault,
+    preserveBuilt: preserveBuilt, preBuildCommand: preBuildCommand)
 
 template withAlpmConfig*(config: Config, passDbs: bool,
   handle: untyped, alpmDbs: untyped, errors: untyped, body: untyped): untyped =

--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -844,7 +844,7 @@ proc printAllWarnings(config: Config, installed: seq[Installed], rpcInfos: seq[R
         not rpcInfoTable.hasKey(inst.name):
         printWarning(config.color, tr"$# was not found in AUR" % [inst.name])
 
-  if upgradeCount == 1:
+  if upgradeCount == 1 and config.printLocalIsNewer:
     for localIsNewer in localIsNewerSeq:
       printWarning(config.color, tra("%s: local (%s) is newer than %s (%s)\n") %
         [localIsNewer.name, localIsNewer.version, config.aurRepo, localIsNewer.aurVersion])


### PR DESCRIPTION
Print warnings during upgrade operation when local packages are newer than those found in remote repositories.

This was previously a default option, now added as a default config option in pakku.conf.