### PR TITLE
Add support for pacman's progress bar Easter egg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+nimcache
+completion/bash
+completion/zsh
+lib/tools
+src/pakku
+doc/pakku.8
+doc/pakku.8.in
+doc/pakku.conf.5
+doc/pakku.conf.5.in

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ src/pakku: src/main.nim $(shell find src -name \*.nim)
 	@echo "NIM: $@"
 	@nim c ${NIM_OPTIONS} \
 	--nimcache:"${NIM_CACHE_DIR}/main" \
+	-d:nimWorkaround14447 \
 	-o:"$@" "$<"
 
 clean:

--- a/src/common.nim
+++ b/src/common.nim
@@ -233,10 +233,10 @@ proc queryUnrequired*(handle: ptr AlpmHandle, withOptional: bool, withoutOptiona
       installed.add(pkg.toPackageReference)
       if pkg.reason == AlpmReason.explicit:
         explicit &= $pkg.name
-      dependsTable.add($pkg.name,
-        depends.map(x => (x, false)) + optional.map(x => (x, true)))
+      dependsTable[$pkg.name] =
+        depends.map(x => (x, false)) + optional.map(x => (x, true))
       if provides.len > 0:
-        alternatives.add($pkg.name, provides)
+        alternatives[$pkg.name] = provides
 
     (installed, explicit.toHashSet + assumeExplicit, dependsTable, alternatives)
 
@@ -484,7 +484,7 @@ proc cloneBareRepo(config: Config, bareKind: BareKind, bareName: string,
 
   if forkWait(() => (block:
     if not dropPrivileges or dropPrivileges():
-      if existsDir(repoPath):
+      if dirExists(repoPath):
         let branch = branchOption.get("master")
         execResult(gitCmd, "-C", repoPath, "fetch", "-q", "--no-tags",
           "origin", branch & ":" & branch)
@@ -665,7 +665,7 @@ proc cloneAurRepo*(config: Config, base: string, gitUrl: string,
 
   if message.isSome:
     (1, message)
-  elif repoPath.existsDir():
+  elif repoPath.dirExists():
     (0, none(string))
   else:
     let fullName = bareFullName(BareKind.pkg, base)
@@ -674,7 +674,7 @@ proc cloneAurRepo*(config: Config, base: string, gitUrl: string,
 
     let cloneBareCode = forkWait(() => (block:
       if not dropPrivileges or dropPrivileges():
-        if existsDir(bareRepoPath):
+        if dirExists(bareRepoPath):
           execResult(gitCmd, "-C", bareRepoPath, "fetch", "-q", "--no-tags",
             "origin", "master:master")
         else:

--- a/src/config.nim
+++ b/src/config.nim
@@ -18,6 +18,7 @@ type
     arch: string,
     debug: bool,
     progressBar: bool,
+    chomp: bool,
     verbosePkgLists: bool,
     downloadTimeout: bool,
     pgpKeyserver: Option[string],
@@ -178,8 +179,8 @@ proc obtainConfig*(config: PacmanConfig): Config =
       [aurRepo, tra"wrong or NULL argument passed"], colorNeeded = some(color))
 
   ((config.common.dbs, config.common.arch, config.common.debug, config.common.progressBar,
-    config.common.verbosePkgLists, config.common.downloadTimeout, config.common.pgpKeyserver,
-    config.common.defaultRoot and config.sysrootOption.isNone,
+    config.common.chomp, config.common.verbosePkgLists, config.common.downloadTimeout,
+    config.common.pgpKeyserver, config.common.defaultRoot and config.sysrootOption.isNone,
     config.common.ignorePkgs, config.common.ignoreGroups),
     root, db, cache, userCacheInitial, userCacheCurrent, tmpRootInitial, tmpRootCurrent,
     color, aurRepo, aurComments, checkIgnored, ignoreArch, printAurNotFound, printLocalIsNewer,

--- a/src/config.nim
+++ b/src/config.nim
@@ -81,9 +81,9 @@ proc readConfigFile*(configFile: string):
                 table[currentCategory] = category
             elif currentCategory.len > 0:
               if line.match(re"(\w+)\ *=\ *(.*)", matches):
-                category[].add(matches[0], matches[1])
+                category[matches[0]] = matches[1]
               else:
-                category[].add(line, "")
+                category[line] = ""
 
         false
       except EOFError:

--- a/src/feature/syncclean.nim
+++ b/src/feature/syncclean.nim
@@ -31,7 +31,7 @@ proc handleSyncClean*(args: seq[Argument], config: Config): int =
       else:
         echo(tr"removing all package repositories...")
 
-      if existsDir(reposCacheDir):
+      if dirExists(reposCacheDir):
         withAlpmConfig(config, false, handle, dbs, errors):
           for e in errors: printError(config.color, e)
 

--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -42,7 +42,7 @@ proc createCloneProgress(config: Config, count: int, flexible: bool, printMode: 
   (proc (update: int, terminate: int) {.closure.}, proc {.closure.}) =
   if count >= 1 and not printMode:
     let (update, terminate) = printProgressShare(config.common.progressBar,
-      tr"cloning repositories")
+      config.common.chomp, tr"cloning repositories")
     update(0, count)
 
     if flexible:

--- a/src/feature/syncsource.nim
+++ b/src/feature/syncsource.nim
@@ -133,7 +133,7 @@ proc cloneAndCopy(config: Config, quiet: bool, fullTargets: seq[FullPackageTarge
       (proc (a: int, b: int) {.closure, sideEffect.} = discard,
         proc () {.closure, sideEffect.} = discard)
     else:
-      printProgressShare(config.common.progressBar, tr"cloning repositories")
+      printProgressShare(config.common.progressBar, config.common.chomp, tr"cloning repositories")
 
   let (results, rerrors) = cloneRepositories(config, baseTargets, update)
   terminate()

--- a/src/pacman.nim
+++ b/src/pacman.nim
@@ -299,6 +299,7 @@ proc createConfigFromTable(table: Table[string, string], dbs: seq[string]): Pacm
   let cacheRel = table.opt("CacheDir")
   let gpgRel = table.opt("GPGDir")
   let color = if table.hasKey("Color"): ColorMode.colorAuto else: ColorMode.colorNever
+  let chomp = table.hasKey("ILoveCandy")
   let verbosePkgLists = table.hasKey("VerbosePkgLists")
   let downloadTimeout = not table.hasKey("DisableDownloadTimeout")
   let arch = table.opt("Architecture").get("auto")
@@ -310,7 +311,7 @@ proc createConfigFromTable(table: Table[string, string], dbs: seq[string]): Pacm
     raise commandError(tr"can not get the architecture",
       colorNeeded = some(color.get))
 
-  ((dbs, archFinal, false, true, verbosePkgLists, downloadTimeout, none(string), true,
+  ((dbs, archFinal, false, true, chomp, verbosePkgLists, downloadTimeout, none(string), true,
     ignorePkgs, ignoreGroups), none(string), rootRel, dbRel, cacheRel, gpgRel, color)
 
 proc obtainPacmanConfig*(args: seq[Argument]): PacmanConfig =
@@ -385,7 +386,7 @@ proc obtainPacmanConfig*(args: seq[Argument]): PacmanConfig =
   let argsRootRel = rootRel.get("/")
   let defaultRoot = defaultRootRel == argsRootRel
 
-  let config: PacmanConfig = ((defaultConfig.common.dbs, arch, debug, progressBar,
+  let config: PacmanConfig = ((defaultConfig.common.dbs, arch, debug, progressBar, defaultConfig.common.chomp,
     defaultConfig.common.verbosePkgLists, defaultConfig.common.downloadTimeout and downloadTimeout,
     pgpKeyserver, defaultRoot, ignorePkgs + defaultConfig.common.ignorePkgs,
     ignoreGroups + defaultConfig.common.ignoreGroups),


### PR DESCRIPTION
This pull request implements replacing the `###---` progress bar with the `-C o o` style, based on `/etc/pacman.conf`. Since pakku wraps pacman in places, this will make both outputs look the same. 

It also includes two commits I made to get Nim building that are probably poorly and unsafely done, and can be trashed if need be.